### PR TITLE
Rails 7.1 support (aka Activeadmin dep lower than 4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
+.idea/
 .bundle/
 .bin
+
+# Fixed ruby version
+.ruby-version
 
 # sqlite files
 *.sqlite3
@@ -12,5 +16,7 @@ tmp/
 
 # Dummy app ignored stuff
 spec/dummy/db/*.sqlite3
+spec/dummy/db/*.sqlite3-shm
+spec/dummy/db/*.sqlite3-wal
 spec/dummy/log/*.log
 spec/dummy/tmp/

--- a/Appraisals
+++ b/Appraisals
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 appraise 'rails5_2' do
   gem 'rails', '~> 5.2.7'
   gem 'activeadmin', '~> 1.4.3'
@@ -14,7 +16,7 @@ appraise 'rails6_1' do
 
   group :test do
     gem 'capybara', '~> 3.33'
-    gem 'selenium-webdriver', '~> 4.1.0'
+    gem 'selenium-webdriver', '~> 4.26.0'
     gem 'puma'
   end
 end
@@ -25,7 +27,18 @@ appraise 'rails7_0' do
 
   group :test do
     gem 'capybara', '~> 3.33'
-    gem 'selenium-webdriver', '~> 4.1.0'
+    gem 'selenium-webdriver', '~> 4.26.0'
     gem 'puma'
+  end
+end
+
+appraise 'rails7_1' do
+  gem 'rails', '~> 7.1'
+  gem 'activeadmin', '~> 3.3.0'
+
+  group :test do
+    gem 'capybara', '~> 3.33'
+    gem 'selenium-webdriver', '~> 4.26.0'
+    gem 'puma', '~> 7.0.2'
   end
 end

--- a/README.md
+++ b/README.md
@@ -5,9 +5,18 @@ Makes it easy to translate your resource fields.
 [![Gem Version](https://badge.fury.io/rb/activeadmin-globalize-2.svg)](http://badge.fury.io/rb/activeadmin-globalize-2)
 [![Build Status](https://app.travis-ci.com/Celkee/activeadmin-globalize-2.svg?branch=master)](https://app.travis-ci.com/Celkee/activeadmin-globalize-2)
 
+## Deprecation warnings
+
+Ruby versions below 3.2 and Rails versions below 7.2 have reached their end of support. Support for older versions of
+these dependencies in this library will be dropped from the main branch soon and moved into stale unmaintained branches
+for historical reasons.
+
+While switching to these unmaintained branches will be a possibility, we recommend that you upgrade ruby / rails on your
+projects instead.
+
 ## Installation
 
-Current version targets Rails >= 5.2 and ActiveAdmin >= 1.3.0.
+Current version targets Rails >= 5.2 and < 7.2 and ActiveAdmin >= 1.3.0.
 
 ```ruby
 gem 'activeadmin-globalize-2', '~> 2.0.0'
@@ -92,6 +101,25 @@ to symbol (in application.rb)
 
 ```ruby
   config.i18n.available_locales = [:en, :it, :de, :es, :"pt-BR"]
+```
+
+
+## Testing
+
+There is currently a bit of a burden in running all tests and guaranteeing the efficacy of the library for all different
+setups. The `.travis.yml` file gives a good idea of what ruby/rails version combinations have been confirmed to work in
+the past, although we don't currently have a CI environment setup for this library.
+
+The recommendation at this specific point is to set ruby to 3.1.2 and run the tests only for rails 7.1. These
+instructions will be updated soon as we verify support for rails 7.2 and ruby 3.2.
+
+### Testing for rails 7.1 (these instructions also currently work for rails 6.1, 7.0)
+```sh
+rbenv local 3.1.2  # Latest ruby version currently supported
+bundle install
+bundle exec appraisal install
+bundle exec rake db:schema:load
+bundle exec appraisal rails7_1 rspec spec
 ```
 
 ## Credits

--- a/activeadmin-globalize-2.gemspec
+++ b/activeadmin-globalize-2.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{app,config,db,lib}/**/*'] + %w(MIT-LICENSE README.md)
 
-  s.add_dependency 'activeadmin', '>= 1.3', '< 3.0'
+  s.add_dependency 'activeadmin', '>= 1.3', '< 4.0'
   s.add_dependency 'globalize', '>= 5.2', '< 7.0'
 
   # development dependencies

--- a/activeadmin-globalize-2.gemspec
+++ b/activeadmin-globalize-2.gemspec
@@ -7,7 +7,7 @@ require 'active_admin/globalize/version'
 Gem::Specification.new do |s|
   s.name        = 'activeadmin-globalize-2'
   s.version     = ActiveAdmin::Globalize::VERSION
-  s.authors     = ['Stefano Verna', 'Fabio Napoleoni', 'tkalliom']
+  s.authors     = ['Stefano Verna', 'Fabio Napoleoni', 'tkalliom', 'shundread']
   s.homepage    = 'http://github.com/Celkee/activeadmin-globalize-2'
   s.summary     = 'Handles globalize translations'
   s.description = 'Handles globalize translations in ActiveAdmin >=1.3 and Rails >=5.2'

--- a/gemfiles/rails6_1.gemfile
+++ b/gemfiles/rails6_1.gemfile
@@ -19,7 +19,7 @@ group :test do
   gem "spring-commands-rspec", require: false
   gem "capybara", "~> 3.33"
   gem "capybara-screenshot"
-  gem "selenium-webdriver", "~> 4.1.0"
+  gem "selenium-webdriver", "~> 4.26.0"
   gem "fuubar", "~> 2.2"
   gem "appraisal"
   gem "awesome_print"

--- a/gemfiles/rails7_1.gemfile
+++ b/gemfiles/rails7_1.gemfile
@@ -7,8 +7,8 @@ gem "therubyrhino", platforms: :ruby
 gem "uglifier"
 gem "jquery-rails"
 gem "devise", "~> 4.5"
-gem "rails", "~> 7.0.2"
-gem "activeadmin", "~> 2.12.0"
+gem "rails", "~> 7.1"
+gem "activeadmin", "~> 3.3.0"
 
 group :test do
   gem "sqlite3", "~> 1.4.2"
@@ -24,7 +24,7 @@ group :test do
   gem "appraisal"
   gem "awesome_print"
   gem "pry"
-  gem "puma"
+  gem "puma", "~> 7.0.2"
 end
 
 gemspec path: "../"

--- a/spec/dummy/app/models/article.rb
+++ b/spec/dummy/app/models/article.rb
@@ -1,5 +1,20 @@
+# frozen_string_literal: true
+
 class Article < ActiveRecord::Base
   # Translated fields with globalize and for active admin
   active_admin_translates :title, :body
 
+  class Translation
+    def self.ransackable_attributes(_auth_object = nil)
+      %w[article_id body created_at id id_value locale title updated_at]
+    end
+  end
+
+  def self.ransackable_associations(_auth_object = nil)
+    %w[translations]
+  end
+
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[created_at id id_value updated_at] + _ransackers.keys
+  end
 end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../boot', __FILE__)
-
+require 'logger' # Tests with Ruby 3.1.2, Rails 6.1 combo will choke in the next line if this import is missing
 require 'rails/all'
 
 # Require the gems listed in Gemfile, including any gems


### PR DESCRIPTION
Digging a bit deeper on the tests and examining `.travis.yml` revealed some more info on getting older tests to run. I didn't bother checking rails 5 support beyond this, as I trust that older versions had been previously tested, I just wanted to check that the update doesn't break rails 6.1/7.0.

Functionally, this is the same PR as [this one](https://github.com/Celkee/activeadmin-globalize-2/pull/3), which did simply this meaningful change (check 1st commit only, 2nd commit was made post-approval and it isn't as tidy as this):

```diff
-  s.add_dependency 'activeadmin', '>= 1.3', '< 3.0'
+  s.add_dependency 'activeadmin', '>= 1.3', '< 4.0'
```

Except that it patches/documents test execution for rails 6.1/7.0/7.1